### PR TITLE
Fix vendored deps in lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,6 @@ dependencies = [
 [[package]]
 name = "cipherstash-client"
 version = "0.6.0"
-source = "git+ssh://git@github.com/cipherstash/cipherstash-suite.git?branch=feat/compound-spike#4bd0ce2ccb3f6c2cda0ad9af35781fec8cb3093c"
 dependencies = [
  "async-mutex",
  "async-once-cell",
@@ -827,7 +826,6 @@ dependencies = [
 [[package]]
 name = "cipherstash-core"
 version = "0.1.1"
-source = "git+ssh://git@github.com/cipherstash/cipherstash-suite.git?branch=feat/compound-spike#4bd0ce2ccb3f6c2cda0ad9af35781fec8cb3093c"
 dependencies = [
  "hmac",
  "lazy_static",
@@ -1949,9 +1947,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.5+3.1.3"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
 dependencies = [
  "cc",
 ]
@@ -1972,7 +1970,6 @@ dependencies = [
 [[package]]
 name = "ore-rs"
 version = "0.7.0"
-source = "git+https://github.com/cipherstash/ore.rs#602baccc86d417184fbb1db6b7d6a47237e8fede"
 dependencies = [
  "aes",
  "block-modes",
@@ -2231,7 +2228,6 @@ dependencies = [
 [[package]]
 name = "recipher"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cipherstash/vitur-rs.git?branch=main#283945a1123fcae11a3d9d018017058864749edb"
 dependencies = [
  "aes",
  "async-trait",
@@ -2640,9 +2636,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -2668,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3073,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3319,7 +3315,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vitur-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cipherstash/vitur-rs.git?branch=main#283945a1123fcae11a3d9d018017058864749edb"
 dependencies = [
  "aes-gcm-siv",
  "async-mutex",
@@ -3348,7 +3343,6 @@ dependencies = [
 [[package]]
 name = "vitur-config"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cipherstash/vitur-rs.git?branch=main#283945a1123fcae11a3d9d018017058864749edb"
 dependencies = [
  "serde",
  "thiserror",
@@ -3357,7 +3351,6 @@ dependencies = [
 [[package]]
 name = "vitur-protocol"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cipherstash/vitur-rs.git?branch=main#283945a1123fcae11a3d9d018017058864749edb"
 dependencies = [
  "async-trait",
  "base64 0.20.0",
@@ -3681,18 +3674,18 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c48d63854f77746c68a5fbb4aa17f3997ece1cb301689a257af8cb80610d21"
+checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c258c1040279e4f88763a113de72ce32dde2d50e2a94573f15dd534cea36a16d"
+checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ aes = "0.8.3"
 hex = { version = "0.4.3", features = [ "serde" ] }
 cryptonamo-derive = { path = "cryptonamo-derive" }
 
-#cipherstash-client = { path = "../../cipherstash-suite/packages/cipherstash-client/", features = [ "tokio" ] }
-cipherstash-client = { git = "ssh://git@github.com/cipherstash/cipherstash-suite.git", branch = "feat/compound-spike", package = "cipherstash-client", features = [ "tokio" ] }
+cipherstash-client = { path = "./vendor/cipherstash-client/", features = [ "tokio" ] }
+# cipherstash-client = { git = "ssh://git@github.com/cipherstash/cipherstash-suite.git", branch = "feat/compound-spike", package = "cipherstash-client", features = [ "tokio" ] }
 
 async-trait = "0.1.73"
 serde_with = "3.3.0"
@@ -45,4 +45,3 @@ env_logger = "0.10.0"
 itertools = "0.11.0"
 thiserror = "1.0.50"
 tokio-stream = "0.1.14"
-

--- a/cryptonamo-derive/Cargo.toml
+++ b/cryptonamo-derive/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = {version = "2.0.31", features = [ "parsing" ]}
 
-cipherstash-client = { git = "ssh://git@github.com/cipherstash/cipherstash-suite.git", branch = "feat/compound-spike", package = "cipherstash-client", features = [ "tokio" ] }
-#cipherstash-client = { path = "../../../cipherstash-suite/packages/cipherstash-client/", features = [ "tokio" ] }
+#cipherstash-client = { git = "ssh://git@github.com/cipherstash/cipherstash-suite.git", package = "cipherstash-client", features = [ "tokio" ] }
+cipherstash-client = { path = "../vendor/cipherstash-client/", features = [ "tokio" ] }

--- a/vendor/cipherstash-client/Cargo.toml
+++ b/vendor/cipherstash-client/Cargo.toml
@@ -50,13 +50,13 @@ features = [
 default_features = false
 
 [dependencies.cipherstash-core]
-path = "../../packages/cipherstash-core"
+path = "../cipherstash-core/"
 
 [dependencies.open]
 version = "3.0.3"
 
 [dependencies.ore-rs]
-git = "https://github.com/cipherstash/ore.rs"
+path = "../ore-rs/"
 
 [dependencies.reqwest]
 version = "0.11.12"
@@ -68,8 +68,7 @@ features = [
 default-features = false
 
 [dependencies.schema]
-git = "ssh://git@github.com/cipherstash/vitur-rs.git"
-branch = "main"
+path = "../vitur-config/"
 package = "vitur-config"
 
 [dependencies.serde]
@@ -82,12 +81,10 @@ features = ["full"]
 optional = true
 
 [dependencies.vitur-client]
-git = "ssh://git@github.com/cipherstash/vitur-rs.git"
-branch = "main"
+path = "../vitur-client/"
 
 [dependencies.vitur-protocol]
-git = "ssh://git@github.com/cipherstash/vitur-rs.git"
-branch = "main"
+path = "../vitur-protocol/"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/vendor/vitur-client/Cargo.toml
+++ b/vendor/vitur-client/Cargo.toml
@@ -59,11 +59,11 @@ version = "1"
 features = ["full"]
 
 [dependencies.vitur-config]
-path = "../config/"
+path = "../vitur-config/"
 
 [dependencies.vitur-protocol]
 version = "0.1.0"
-path = "../protocol"
+path = "../vitur-protocol/"
 
 [dev-dependencies]
 serde_json = "1.0.89"

--- a/vendor/vitur-protocol/Cargo.toml
+++ b/vendor/vitur-protocol/Cargo.toml
@@ -25,7 +25,7 @@ version = "1.0.150"
 features = ["derive"]
 
 [dependencies.vitur-config]
-path = "../config"
+path = "../vitur-config/"
 
 [dev-dependencies]
 serde_json = "1.0.89"


### PR DESCRIPTION
Fixes up the vendored dependencies when cryptonamo is used as a library. I tried to use the `[patch]` feature of `Cargo.toml` to make the `git` dependencies look at local paths instead but this didn't work.

We'll just have to make sure when we update vendored dependencies we review changes to the vendored libs Cargo.toml files.