### PR TITLE
Disable source code generation in docs for now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_no_source)]
 #![doc(html_favicon_url = "https://cipherstash.com/favicon.ico")]
 //! ## Cryptonamo: Encrypted Tables for DynamoDB
 //!


### PR DESCRIPTION
Docs will be published without source code (at least until such time as we release on crates.io).