### PR TITLE
Split public api into a non-generic raw version and generic version

### DIFF
--- a/cipherstash-dynamodb-derive/src/decryptable.rs
+++ b/cipherstash-dynamodb-derive/src/decryptable.rs
@@ -16,18 +16,18 @@ pub(crate) fn derive_decryptable(input: DeriveInput) -> Result<TokenStream, syn:
 
     let from_unsealed_impl = protected_attributes
         .iter()
-        .map(|(attr, ty)| {
+        .map(|attr| {
             let attr_ident = format_ident!("{attr}");
 
             quote! {
-                #attr_ident: ::cipherstash_dynamodb::traits::TryFromPlaintext::try_from_plaintext(unsealed.get_protected::<#ty>(#attr))?
+                #attr_ident: ::cipherstash_dynamodb::traits::TryFromPlaintext::try_from_plaintext(unsealed.get_protected(#attr)?.to_owned())?
             }
         })
         .chain(plaintext_attributes.iter().map(|attr| {
             let attr_ident = format_ident!("{attr}");
 
             quote! {
-                #attr_ident: ::cipherstash_dynamodb::traits::TryFromTableAttr::try_from_table_attr(unsealed.get_plaintext(#attr))?
+                #attr_ident: ::cipherstash_dynamodb::traits::TryFromTableAttr::try_from_table_attr(unsealed.get_plaintext(#attr)?)?
             }
         }))
         .chain(skipped_attributes.iter().map(|attr| {

--- a/cipherstash-dynamodb-derive/src/encryptable.rs
+++ b/cipherstash-dynamodb-derive/src/encryptable.rs
@@ -19,11 +19,7 @@ pub(crate) fn derive_encryptable(input: DeriveInput) -> Result<TokenStream, syn:
         .map(|x| quote! { Some(#x) })
         .unwrap_or_else(|| quote! { None });
 
-    let protected_attributes = settings
-        .protected_attributes()
-        .into_iter()
-        .map(|(attr, _ty)| attr)
-        .collect::<Vec<_>>();
+    let protected_attributes = settings.protected_attributes();
     let plaintext_attributes = settings.plaintext_attributes();
     let ident = settings.ident();
 

--- a/cipherstash-dynamodb-derive/src/settings/builder.rs
+++ b/cipherstash-dynamodb-derive/src/settings/builder.rs
@@ -1,7 +1,7 @@
 use super::{index_type::IndexType, AttributeMode, Settings};
 use proc_macro2::{Ident, Span};
 use std::collections::HashMap;
-use syn::{Data, DeriveInput, Fields, LitStr, Type};
+use syn::{Data, DeriveInput, Fields, LitStr};
 
 enum SortKeyPrefix {
     Default,
@@ -27,7 +27,7 @@ pub(crate) struct SettingsBuilder {
     sort_key_prefix: SortKeyPrefix,
     sort_key_field: Option<String>,
     partition_key_field: Option<String>,
-    protected_attributes: Vec<(String, Type)>,
+    protected_attributes: Vec<String>,
     unprotected_attributes: Vec<String>,
     skipped_attributes: Vec<String>,
     indexes: Vec<IndexType>,
@@ -124,7 +124,6 @@ impl SettingsBuilder {
 
                 for field in &fields_named.named {
                     let ident = &field.ident;
-                    let ty = field.ty.clone();
                     let mut attr_mode = AttributeMode::Protected;
 
                     let field_name = ident
@@ -322,7 +321,6 @@ impl SettingsBuilder {
                             .as_ref()
                             .ok_or(syn::Error::new_spanned(field, "missing field"))?
                             .to_string(),
-                        ty,
                         attr_mode,
                     );
                 }
@@ -381,9 +379,9 @@ impl SettingsBuilder {
         Ok(())
     }
 
-    fn add_attribute(&mut self, value: String, ty: Type, mode: AttributeMode) {
+    fn add_attribute(&mut self, value: String, mode: AttributeMode) {
         match mode {
-            AttributeMode::Protected => self.protected_attributes.push((value, ty)),
+            AttributeMode::Protected => self.protected_attributes.push(value),
             AttributeMode::Plaintext => self.unprotected_attributes.push(value),
             AttributeMode::Skipped => self.skipped_attributes.push(value),
         }

--- a/cipherstash-dynamodb-derive/src/settings/mod.rs
+++ b/cipherstash-dynamodb-derive/src/settings/mod.rs
@@ -3,7 +3,7 @@ pub mod index_type;
 use self::{builder::SettingsBuilder, index_type::IndexType};
 use itertools::Itertools;
 use proc_macro2::Ident;
-use syn::{DeriveInput, Type};
+use syn::DeriveInput;
 
 pub(crate) enum AttributeMode {
     Protected,
@@ -17,7 +17,7 @@ pub(crate) struct Settings {
     pub(crate) type_name: String,
     pub(crate) sort_key_field: Option<String>,
     pub(crate) partition_key_field: String,
-    protected_attributes: Vec<(String, Type)>,
+    protected_attributes: Vec<String>,
     unprotected_attributes: Vec<String>,
 
     /// Skipped attributes are never encrypted by the `DecryptedRecord` trait will
@@ -35,11 +35,11 @@ impl Settings {
         &self.ident
     }
 
-    pub(crate) fn protected_attributes(&self) -> Vec<(&str, &Type)> {
+    pub(crate) fn protected_attributes(&self) -> Vec<&str> {
         self.protected_attributes
             .iter()
-            .map(|(ident, ty)| (ident.as_str(), ty))
-            .sorted_by_key(|(ident, _ty)| *ident)
+            .map(|s| s.as_str())
+            .sorted()
             .collect::<Vec<_>>()
     }
 

--- a/src/crypto/unsealed.rs
+++ b/src/crypto/unsealed.rs
@@ -1,5 +1,5 @@
 use crate::{encrypted_table::TableAttribute, Decryptable};
-use cipherstash_client::encryption::{Plaintext, PlaintextNullVariant};
+use cipherstash_client::encryption::Plaintext;
 use std::collections::HashMap;
 
 use super::SealError;
@@ -32,22 +32,20 @@ impl Unsealed {
         }
     }
 
-    pub fn get_protected<T>(&self, name: &str) -> Plaintext
-    where
-        T: PlaintextNullVariant,
-    {
-        self.protected
+    pub fn get_protected(&self, name: &str) -> Result<&Plaintext, SealError> {
+        let (plaintext, _) = self
+            .protected
             .get(name)
-            .map(|(plaintext, _)| plaintext)
-            .cloned()
-            .unwrap_or_else(|| T::null())
+            .ok_or_else(|| SealError::MissingAttribute(name.to_string()))?;
+
+        Ok(plaintext)
     }
 
-    pub fn get_plaintext(&self, name: &str) -> TableAttribute {
+    pub fn get_plaintext(&self, name: &str) -> Result<TableAttribute, SealError> {
         self.unprotected
             .get(name)
             .cloned()
-            .unwrap_or(TableAttribute::Null)
+            .ok_or_else(|| SealError::MissingAttribute(name.to_string()))
     }
 
     pub fn add_protected(&mut self, name: impl Into<String>, plaintext: Plaintext) {


### PR DESCRIPTION
### Motivation
#### Mocking and object safety
As we have probably mentioned before, we need the ability to mock your `cipherstash_dynamodb::EncryptedTable` so we can unit test our code (running a local dynamodb is not always a viable option). The pattern we use when we want a mockable version of e.g some `Client`, is to create a trait `I` that covers all functionality of `Client`, that we can then implement on a `MockClient` and on a real `Client`. To avoid having generics littered all over our code base, we use `Arc<dyn I>`or similar, that we can then instantiate with either a `MockClient` or a real `Client`.

This strategy is currently not possible with `EncryptedTable`, since the public functions are generic over the model `T` and thus we can't make a object safe trait that covers the functionality of `EncryptedTable`. 

#### Manual handling of encrypted and decrypted records (aka. `Sealed` and `Unsealed`)
We need to be able to encrypt/decrypt records manually, i.e without serializing from/to a struct that derives `Encryptable, Decryptable` and `Seachable` and without calling `EncryptedTable::get`and `EncryptedTable::put` directly.

One example where we need to manually decrypt is when we query the database through a custom non-encrypted GSI, which results in one or more raw `HashMap<String, AttributeVaue>` records. However, currently we are unable to decrypt the encrypted attributes.

Similarly we need to be able to manually encrypt, so we can construct and inject GSI attributes that is not part of the model before it's encrypted and inserted into the database. Basically we want to do the following transform;
```
T -> Unsealed -> Inject custom GSI values -> Sealed -> Insert
```
where `T` is a model that derives `Encryptable`, `Decryptable` and `Searchable`.

### API changes and what they solve
#### Changes
There are mainly two kind of changes: 1. making more functionality public and splitting functions that are generic over some model type `T` into a generic function and a raw non-generic function. All the non-generic functions contains the main body of the original function, but takes all the meta data from `T` as arguments. The generic functions extracts the meta data from their generic `T` and feeds it to their non-generic counterpart.

The following methods on `EncryptedTable` have all kept their original function signature, however for every function an additional "raw" function has been added:
```rust
/// Original
fn get_primary_key_parts<T: Encryptable>(
        &self,
        k: impl Into<T::PrimaryKey>,
    ) -> Result<PrimaryKeyParts, EncryptionError>
/// Added raw function 
fn encrypt_primary_key_parts(
        &self,
        PrimaryKeyParts { mut pk, mut sk }: PrimaryKeyParts,
        is_partition_key_encrypted: bool,
        is_sort_key_encrypted: bool,
    ) -> Result<PrimaryKeyParts, EncryptionError> 
    
/// Original
async fn get<T>(&self, k: impl Into<T::PrimaryKey>) -> Result<Option<T>, GetError>
    where
        T: Decryptable
/// Added raw function
async fn get_raw(
        &self,
        PrimaryKeyParts { pk, sk }: PrimaryKeyParts,
        plaintext_attributes: &[&'static str],
        decryptable_attributes: &[&'static str],
    ) -> Result<Option<Unsealed>, GetError>

/// Original
async fn delete<E: Searchable>(
        &self,
        k: impl Into<E::PrimaryKey>,
    ) -> Result<(), DeleteError>
/// Added raw function
async fn delete_raw(
        &self,
        PrimaryKeyParts { pk, sk }: PrimaryKeyParts,
        all_index_keys: Vec<String>,
    ) -> Result<(), DeleteError>

/// Original
async fn put<t>(&self, record: t) -> result<(), puterror>
    where
        t: searchable
/// Added raw function
async fn put_raw(
        &self,
        PrimaryKeyParts { pk, .. }: PrimaryKeyParts,
        sealed: Vec<Sealed>,
        all_index_keys: Vec<String>,
    ) -> Result<(), PutError>

/// Original
fn query<R>(&self) -> QueryBuilder<R>
    where
        R: Searchable + Decryptable
/// Added raw function
fn query_raw(&self) -> RawQueryBuilder     // <---- More about this one later
```
Similarly to the above, the `QueryBuilder` has been split into a generic struct over the model `T` and a non-generic struct. All the original core logic that builds the query have been moved to non-generic `RawQueryBuilder`. To construct the final DynamoDB query, the `RawQueryBuilder` extends the signature of the `send` function with the following arguments:
```rust
async fn send(
        self,
        type_name: &'static str,
        index_by_name: impl Fn(&str, IndexType) -> Option<Box<dyn ComposableIndex>>,
        plaintext_attributes: &[&'static str],
        decryptable_attributes: &[&'static str],
    ) -> Result<Vec<Unsealed>, QueryError>
```
The generic `QueryBuilder` then calls the `RawQueryBuilder` with the model meta data obtained from it's type parameter:
```rust
impl<'t, T> QueryBuilder<'t, T>
where
    T: Searchable + Decryptable,
{
    ...
    
    pub async fn send(self) -> Result<Vec<T>, QueryError> {
        self.raw_builder
            .send(
                T::type_name(),
                T::index_by_name,
                T::plaintext_attributes(),
                T::decryptable_attributes(),
            )
            .await?
            .into_iter()
            .map(|unsealed| Ok(T::from_unsealed(unsealed)?))
            .collect::<Result<Vec<_>, QueryError>>()
    }
}
``` 

The `Sealer` type has also been changed, such that you can seal `Unsealed` records without knowing the model type `T` but by just knowing the meta data about `T`. You now initialize `Sealer` with the model meta data with the following function:
```rust
fn new(
        cipher: &'e Encryption<C>,
        is_partition_key_encrypted: bool,
        is_sort_key_encrypted: bool,
        index_by_name: fn(&str, IndexType) -> Option<Box<dyn ComposableIndex>>,
        protected_attributes: &'static [&'static str],
        protected_indexes: &'static [(&'static str, IndexType)],
        type_name: &'static str,
    ) -> Self
```
For every `Unsealed` record you want to seal, you call the following function:
```rust
fn push<I>(
        &mut self,
        unsealed: &'p Unsealed,
        partition_key: String,
        sort_key: String,
        attributes_for_indexes: I,
    ) -> Result<(), SealError>
    where
        I: IntoIterator<Item = ComposablePlaintext>
```
which will update the internal state and buffers of the sealer (what's currently done on the stack in the `seal_all` function).
When all `Unsealed` records has been pushed, you can call the following function to get the `Sealed` records:
```rust
async fn finalize(mut self) -> Result<Vec<(PrimaryKeyParts, Vec<Sealed>)>, SealError>
```
I have kept the `Sealer::seal<T>` and `Sealer::seal_all<T>` functions with their original function signature.

#### What the changes solve
With the above described changes it's now possible to use `cipherstash_dynamodb::EncryptedTable` without being generic over the model type `T`, which in turn means it's possible to define and implement an object safe trait that covers the functionality of `EncryptedTable`. As an example, here is a part of the object safe trait I have defined in our code base that I have implemented for `EncryptedTable` and a mock version:
```rust
pub trait CipherStashClientBase {
    ...
    fn get_raw(
        &self,
        primary_key_parts: PrimaryKeyParts,
        plaintext_attributes: &'static [&'static str],
        decryptable_attributes: &'static [&'static str],
    ) -> Pin<Box<dyn Future<Output = Result<Option<Unsealed>, GetError>> + '_>>
}
```
Which is simply implemented on `cipherstash_dynamodb::EncryptedTable` like this:
```rust
impl CipherStashClientBase for EncryptedTable {
    ...
    fn put_raw(
        &self,
        record: Vec<Sealed>,
        primary_key_parts: PrimaryKeyParts,
        all_index_keys: Vec<String>,
    ) -> Pin<Box<dyn Future<Output = Result<(), PutError>> + '_>> {
        Box::pin(async move {
            self.put_raw(primary_key_parts, record, all_index_keys)
                .await
        })
    }

}
```
To avoid having to handle raw model meta data whenever I call the cipherstash functions, I have created an extension trait that is implemented for all types that also implements `CipherStashClientBase`:
```rust
pub trait CipherStashClient: CipherStashClientBase {
    ...
    fn get<T>(
        &self,
        primary_key: impl Into<T::PrimaryKey>,
    ) -> Pin<Box<dyn Future<Output = Result<Option<T>, GetError>> + '_>>
    where
        T: Decryptable,
    {
        let primary_key_parts = match self.encrypt_primary_key_parts(
            primary_key.into().into_parts::<T>(),
            T::is_partition_key_encrypted(),
            T::is_sort_key_encrypted(),
        ) {
            Ok(k) => k,
            Err(e) => return Box::pin(async move { Err(e.into()) }),
        };

        println!("primary_key_parts: {primary_key_parts:#?}");

        let get_fut = self.get_raw(
            primary_key_parts,
            T::plaintext_attributes(),
            T::decryptable_attributes(),
        );

        let fut = async move { Ok(get_fut.await?.map(T::from_unsealed).transpose()?) };

        Box::pin(fut)
    }
}

impl<I> CipherStashClient for I where I: CipherStashClientBase + ?Sized {}
```
As you can see, I'm now fully able to mimic the original behavior of `cipherstash_dynamodb::EncryptedTable` while also being able to mock it.

### Thoughts about extending the API surface
I understand that these changes does create a larger API surface for you to maintain and does expose more of the underlying implementation details. However the current API is a bit too rigid to be useful for the non-trivial cases and I have done my best to keep it as minimal as possible, while still being flexible. I'm prepared for, that these changes will open up for more breaking API changes in the future and I actually encourage them, since many of the `*_raw` functions I've introduced doesn't have the nicest looking function signatures. I have described two ideas below, that I haven't implemented, but could make the raw version of the API nicer to work with in the future.

#### Substitute the many arguments in the `*_raw` functions with dedicated structs.
Since many of the `*_raw` functions takes 2+ of the same model meta data arguments, these could be substituted with e.g. 3 different struct: `EncryptableMetaData`, `DecryptableMeData` and `QueryableMetaData`. The three different proc-macros could then generate a function each that each construct those structs. This would then make e.g. the function `get_raw` look like this:
```rust
async fn get_raw(
        &self,
        meta_data: &DecryptableMetaData,
    ) -> Result<Option<Unsealed>, GetError>
```
This would not only make the API aesthetically more pleasing but also hide some of the implementation details and potentially allow you to make more internal changes with less breaking changes. If you decide to do something like this, I strongly suggest that you make some kind of builder pattern for the meta data structs, such that it's possible to use your API without using your derive macros.

#### Remove database access from the `*_raw` functions
While making these changes, it dawned on me, that on an abstract level all the `*_raw` functions are either `map-reduce` or `map-expand`, and all of the functions results in one or more DynamoDB operations.
Pseudo code example for `get_raw`and `put_raw`:
```
// get_raw takes a primary key, potentially encrypts it and generates exactly one GetItem dynamo operation
get_raw(primary_key) -> DynamoOperation

// put_raw takes a record, encrypts it and generates a list of TransactWriteItem dynamo operations
put_raw(record) -> [DynamoOperation]
```
What this shows us is that it's not really necessary for the `*_raw` functions to access the database to keep the basic semantics of them. If we removed the database access from the `*_raw` functions, then it would easier for users with more advanced use cases to either inspect, modify or delay the `DynamoOperations` before they are executed.
As a extra plus it could potentially be easier to mock, since now we can just change out the DynamoDB client without actually mocking any of the internal functionality of `cipherstash_dynamodb`.
If this change is made, the type `EncryptedTable` should probably be split into two; `EncryptedTable` and `RawEncryptedTable`, since now `RawEncryptedTable` wont have a need for a database client. This would also clean up the public API of `EncryptedTable`, since the `*_raw` methods would be implemented on the `RawEncryptedTable` struct, while the non-raw original functions would implemented on the `EncryptedTable` struct.

### Test status
All tests that passes on `main` also passes in this branch. However I have some tests that fails for me on both `main` and this branch.