### PR TITLE
Move fn `EncryptedTable::prepare_record` to it's own trait `Preparabl…

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,10 +6,7 @@ mod unsealed;
 use std::borrow::Cow;
 
 use crate::{
-    traits::{
-        Encryptable, PrimaryKeyError, PrimaryKeyParts, ReadConversionError, Searchable,
-        WriteConversionError,
-    },
+    traits::{PrimaryKeyError, PrimaryKeyParts, ReadConversionError, WriteConversionError},
     Identifiable, IndexType, PrimaryKey,
 };
 use cipherstash_client::{

--- a/src/crypto/sealer.rs
+++ b/src/crypto/sealer.rs
@@ -1,17 +1,16 @@
 use super::{
-    b64_encode, encrypt_primary_key, format_term_key, hmac, SealError, SealedTableEntry,
-    UnsealSpec, Unsealed, MAX_TERMS_PER_INDEX,
+    b64_encode, format_term_key, hmac, SealError, SealedTableEntry, Unsealed, MAX_TERMS_PER_INDEX,
 };
 use crate::{
     encrypted_table::{TableAttribute, TableEntry},
     traits::PrimaryKeyParts,
-    Identifiable, IndexType, Searchable,
+    IndexType,
 };
 use cipherstash_client::{
     credentials::{service_credentials::ServiceToken, Credentials},
     encryption::{
         compound_indexer::{ComposableIndex, ComposablePlaintext, CompoundIndex},
-        Encryption, IndexTerm, Plaintext,
+        Encryption, IndexTerm,
     },
 };
 use itertools::Itertools;

--- a/tests/headless_tests.rs
+++ b/tests/headless_tests.rs
@@ -1,5 +1,7 @@
 use aws_sdk_dynamodb::Client;
-use cipherstash_dynamodb::{Decryptable, Encryptable, EncryptedTable, Identifiable, Searchable};
+use cipherstash_dynamodb::{
+    traits::Preparable, Decryptable, Encryptable, EncryptedTable, Identifiable, Searchable,
+};
 use serial_test::serial;
 use std::future::Future;
 
@@ -58,8 +60,9 @@ async fn test_headless_roundtrip() {
             .await
             .expect("failed to init table");
 
-        let user_record = table
-            .prepare_record(user.clone())
+        let user_record = user
+            .clone()
+            .prepare_record()
             .expect("failed to prepare record");
 
         let patch = table


### PR DESCRIPTION
Since I can't access the generic functions on `EncryptedTable` I have moved `fn prepare_record` to it's own trait that's blanket implemented on `R: Searchable + Identifiable`.