### PR TITLE
Point to a license file that exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipherstash-dynamodb"
-license-file = "LICENSE"
+license-file = "LICENSE.md"
 homepage = "https://cipherstash.com"
 repository = "https://github.com/cipherstash/cipherstash-dynamodb"
 readme = "README.md"

--- a/cipherstash-dynamodb-derive/Cargo.toml
+++ b/cipherstash-dynamodb-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipherstash-dynamodb-derive"
-license-file = "../LICENSE"
+license-file = "../LICENSE.md"
 homepage = "https://cipherstash.com"
 readme = "../README.md"
 description = "Derive macros for the CipherStash client for DynamoDB"


### PR DESCRIPTION
## Summary

### Changes

Updates `Cargo.toml`s to point to a license file that exists, after the rename in 4f434096e62bc24f336d2a3d135ba22054700e52

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.