### PR TITLE
Add helper functions to `Prepare*` structs `PreparedQuery`

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -107,6 +107,7 @@ where
 }
 
 // Contains all the necessary information to encrypt the primary key pair
+#[derive(Clone)]
 pub struct PreparedPrimaryKey {
     pub primary_key_parts: PrimaryKeyParts,
     pub is_pk_encrypted: bool,

--- a/src/traits/primary_key.rs
+++ b/src/traits/primary_key.rs
@@ -1,3 +1,4 @@
+#[derive(Clone)]
 pub struct PrimaryKeyParts {
     pub pk: String,
     pub sk: String,


### PR DESCRIPTION
* Add fn to `PreparedDelete` that's not generic over the keyparts

* Add `PreparedQueryBuilder`, basically this allows me to "build" to `PreparedQuery` without knowing (forget beforehand) the type of the record `S`. 