### PR TITLE
Fixed issue where value didn't live long enough

### DIFF
--- a/src/crypto/sealed.rs
+++ b/src/crypto/sealed.rs
@@ -110,8 +110,8 @@ impl SealedTableEntry {
 
         let decrypted = async_map_somes(decryptable_items, |items| cipher.decrypt(items)).await?;
         let mut chunks_exact = decrypted.chunks_exact(protected_attributes.len());
-        let mut default_iter = std::iter::repeat_with::<&[Option<Plaintext>], _>(|| &[])
-                    .take(plaintext_items.len());
+        let mut default_iter =
+            std::iter::repeat_with::<&[Option<Plaintext>], _>(|| &[]).take(plaintext_items.len());
 
         let decrypted_iter: &mut dyn Iterator<Item = &[Option<Plaintext>]> =
             if protected_attributes.len() > 0 {


### PR DESCRIPTION
This PR fixes the below:

```
error[E0716]: temporary value dropped while borrowed
   --> src/crypto/sealed.rs:115:22
    |
114 | /             if protected_attributes.len() > 0 {
115 | |                 &mut decrypted.chunks_exact(protected_attributes.len())
    | |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
116 | |             } else {
    | |             - temporary value is freed at the end of this statement
117 | |                 &mut std::iter::repeat_with::<&[Option<Plaintext>], _>(|| &[])
118 | |                     .take(plaintext_items.len())
119 | |             };
    | |_____________- borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
```

<!---
🛑🛑🛑
Have you contacted support@cipherstash.com about this change?

If not, please email before creating a PR.
--->

## Summary

### Changes

> Please provide a summary of what's being changed

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
