### PR TITLE
Pull cipherstash-dynamodb-derive from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "cipherstash-dynamodb"
 license-file = "LICENSE.md"
 homepage = "https://cipherstash.com"
 repository = "https://github.com/cipherstash/cipherstash-dynamodb"
+documentation = "https://docs.rs/cipherstash-dynamodb"
 readme = "README.md"
 description = "CipherStash SDK for searchable, in-use encryption for DynamoDB"
 version = "0.7.1"
@@ -10,9 +11,6 @@ edition = "2021"
 authors = ["CipherStash <info@cipherstash.com>"]
 keywords = ["cryptography", "security", "databases", "encryption", "dynamodb"]
 categories = ["cryptography", "database"]
-
-[package.metadata.docs.rs]
-repository = "https://github.com/cipherstash/cipherstash-dynamodb"
 
 [lib]
 # Starting in Rust 1.62 you can use `cargo add` to add dependencies 
@@ -28,7 +26,7 @@ repository = "https://github.com/cipherstash/cipherstash-dynamodb"
 
 [dependencies]
 cipherstash-client = { version = "0.12" }
-cipherstash-dynamodb-derive = { version = "0.7", path = "cipherstash-dynamodb-derive", registry = "cipherstash" }
+cipherstash-dynamodb-derive = { version = "0.7", path = "cipherstash-dynamodb-derive" }
 
 aws-sdk-dynamodb = "1.3.0"
 async-trait = "0.1.73"


### PR DESCRIPTION
Pull deps from crates. The main crate will be dual published.
Updated the main `Cargo.toml` to link to docs on docs.rs.