### PR TITLE
Add getter functions on `PreparedRecord` and `PreparedDelete`

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 pub use b64_encode::*;
 pub use sealed::{SealedTableEntry, UnsealSpec};
-pub use sealer::Sealer;
+pub use sealer::{Sealer, UnsealedIndex};
 pub use unsealed::Unsealed;
 
 /// In order to stop indexes from exploding with indexes on large strings, cap the number of terms

--- a/src/encrypted_table/mod.rs
+++ b/src/encrypted_table/mod.rs
@@ -169,6 +169,10 @@ impl PreparedRecord {
             .map(|(key, attr)| (key.as_str(), attr))
     }
 
+    pub fn unsealed_indexes(&self) -> &[UnsealedIndex] {
+        &self.sealer.unsealed_indexes
+    }
+
     pub fn prepare_record<R>(record: R) -> Result<Self, SealError>
     where
         R: Searchable + Identifiable,
@@ -227,6 +231,10 @@ impl PreparedRecord {
 
     pub fn type_name(&self) -> &str {
         &self.sealer.type_name
+    }
+
+    pub fn protected_indexes(&self) -> &[(Cow<'static, str>, IndexType)] {
+        &self.protected_indexes
     }
 }
 

--- a/src/encrypted_table/mod.rs
+++ b/src/encrypted_table/mod.rs
@@ -132,6 +132,10 @@ impl PreparedDelete {
     pub fn prepared_primary_key(&self) -> PreparedPrimaryKey {
         self.primary_key.clone()
     }
+
+    pub fn protected_indexes(&self) -> &[(Cow<'static, str>, IndexType)] {
+        &self.protected_indexes
+    }
 }
 
 impl PreparedRecord {


### PR DESCRIPTION
This PR add the following functions:
```rust
PreparedDelete::protected_indexes(&self) -> &[(Cow<'static, str>, IndexType)]

PreparedRecord::unsealed_indexes(&self) -> &[UnsealedIndex]
PreparedRecord::protected_indexes(&self) -> &[(Cow<'static, str>, IndexType)]
```

This basically allows me to fully mock `cipherstash_dynamodb::EncryptedTable` which we need for CI purposes.