### PR TITLE
Pass in `cts_config` to `ZeroKMSConfigBuilder` in `EncryptedTable::init_headless`

### DIFF
--- a/src/encrypted_table/mod.rs
+++ b/src/encrypted_table/mod.rs
@@ -18,7 +18,9 @@ use crate::{
 };
 use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem};
 use cipherstash_client::{
-    config::{console_config::ConsoleConfig, zero_kms_config::ZeroKMSConfig},
+    config::{
+        console_config::ConsoleConfig, cts_config::CtsConfig, zero_kms_config::ZeroKMSConfig,
+    },
     credentials::{
         auto_refresh::AutoRefresh,
         service_credentials::{ServiceCredentials, ServiceToken},
@@ -66,11 +68,16 @@ impl<D> EncryptedTable<D> {
 impl EncryptedTable<Headless> {
     pub async fn init_headless() -> Result<Self, InitError> {
         info!("Initializing...");
+
         let console_config = ConsoleConfig::builder().with_env().build()?;
+
+        let cts_config = CtsConfig::builder().with_env().build()?;
+
         let zero_kms_config = ZeroKMSConfig::builder()
             .decryption_log(true)
             .with_env()
             .console_config(&console_config)
+            .cts_config(&cts_config)
             .build_with_client_key()?;
 
         let zero_kms_client = ZeroKMS::new_with_client_key(


### PR DESCRIPTION
This change updates `EncryptedTable::init_headless` to build its own `CtsConfig` and pass it into `ZeroKMSConfigBuilder`. By default, `ZeroKMSConfigBuilder` will build its own `CtsConfig` without environment variable overrides. Using `CtsConfig::builder().with_env()` and passing that to `ZeroKMSConfigBuilder` allows for overriding CTS config from environment variables.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
