### PR TITLE
Add methods `EncryptedTable::init_headless_with_zk_config` and `Encry…

### DIFF
--- a/src/encrypted_table/mod.rs
+++ b/src/encrypted_table/mod.rs
@@ -78,10 +78,10 @@ impl EncryptedTable<Headless> {
             .cts_config(&cts_config)
             .build_with_client_key()?;
 
-        Self::init_headless_with_zk_config(zerokms_config).await
+        Self::init_headless_with_zerokms_config(zerokms_config).await
     }
 
-    pub async fn init_headless_with_zk_config(
+    pub async fn init_headless_with_zerokms_config(
         zerokms_config: ZeroKMSConfig<ClientKey>,
     ) -> Result<Self, InitError> {
         info!("Initializing...");
@@ -419,12 +419,12 @@ impl EncryptedTable<Dynamo> {
         })
     }
 
-    pub async fn init_with_zk_config(
+    pub async fn init_with_zerokms_config(
         zerokms_config: ZeroKMSConfig<ClientKey>,
         db: aws_sdk_dynamodb::Client,
         table_name: impl Into<String>,
     ) -> Result<Self, InitError> {
-        let table = EncryptedTable::init_headless_with_zk_config(zerokms_config).await?;
+        let table = EncryptedTable::init_headless_with_zerokms_config(zerokms_config).await?;
 
         Ok(Self {
             db: Dynamo {

--- a/src/encrypted_table/mod.rs
+++ b/src/encrypted_table/mod.rs
@@ -23,7 +23,7 @@ use cipherstash_client::{
     },
     credentials::{auto_refresh::AutoRefresh, service_credentials::ServiceCredentials},
     encryption::ScopedCipher,
-    zerokms::{ZeroKMS, ZeroKMSWithClientKey},
+    zerokms::{ClientKey, ZeroKMS, ZeroKMSWithClientKey},
 };
 use log::info;
 use std::{
@@ -67,8 +67,6 @@ impl<D> EncryptedTable<D> {
 
 impl EncryptedTable<Headless> {
     pub async fn init_headless() -> Result<Self, InitError> {
-        info!("Initializing...");
-
         let console_config = ConsoleConfig::builder().with_env().build()?;
 
         let cts_config = CtsConfig::builder().with_env().build()?;
@@ -79,6 +77,14 @@ impl EncryptedTable<Headless> {
             .console_config(&console_config)
             .cts_config(&cts_config)
             .build_with_client_key()?;
+
+        Self::init_headless_with_zk_config(zerokms_config).await
+    }
+
+    pub async fn init_headless_with_zk_config(
+        zerokms_config: ZeroKMSConfig<ClientKey>,
+    ) -> Result<Self, InitError> {
+        info!("Initializing...");
 
         let cipher = ZeroKMS::new_with_client_key(
             &zerokms_config.base_url(),
@@ -403,6 +409,22 @@ impl EncryptedTable<Dynamo> {
         table_name: impl Into<String>,
     ) -> Result<Self, InitError> {
         let table = EncryptedTable::init_headless().await?;
+
+        Ok(Self {
+            db: Dynamo {
+                table_name: table_name.into(),
+                db,
+            },
+            cipher: table.cipher,
+        })
+    }
+
+    pub async fn init_with_zk_config(
+        zerokms_config: ZeroKMSConfig<ClientKey>,
+        db: aws_sdk_dynamodb::Client,
+        table_name: impl Into<String>,
+    ) -> Result<Self, InitError> {
+        let table = EncryptedTable::init_headless_with_zk_config(zerokms_config).await?;
 
         Ok(Self {
             db: Dynamo {


### PR DESCRIPTION
This PR adds the methods `EncryptedTable::init_headless_with_zk_config` and `EncryptedTable::init_with_zk_config`, to make it possible to initialize a `EncryptedTable` with a custom `ZeroKmsConfig`.

We need this since we load the cipherstash credentials/client_key externally and wont have them in the environment.