### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/cipherstash-dynamodb-derive/Cargo.toml
+++ b/cipherstash-dynamodb-derive/Cargo.toml
@@ -6,6 +6,7 @@ readme = "../README.md"
 description = "Derive macros for the CipherStash client for DynamoDB"
 version = "0.8.0"
 edition = "2021"
+repository = "https://github.com/cipherstash/cipherstash-dynamodb/"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.