### PR TITLE
CI: fix typo causing only ignored tests to run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           toolchain: stable
 
       - name: "Run tests"
-        run: cargo test --all-targets -- --ignored
+        run: cargo test --all-targets -- --include-ignored
         env:
           CS_WORKSPACE_ID: ${{ secrets.CS_WORKSPACE_ID }}
           CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}


### PR DESCRIPTION
This change fixes up a typo in the test workflow in CI that's causing only ignored tests to run.

Confusingly, `--ignored` runs *only* ignored tests, but `--include-ignored` runs tests whether they're ignored or not. `--include-ignored` is probably what we want.

Even more confusingly, the `--ignored` and `--include-ignored` flags don't seem to be well documented, but it is mentioned in The Book here: https://doc.rust-lang.org/book/ch11-02-running-tests.html#ignoring-some-tests-unless-specifically-requested.
